### PR TITLE
Feature/on premise

### DIFF
--- a/bitmovintypes/cloud_region.go
+++ b/bitmovintypes/cloud_region.go
@@ -18,4 +18,5 @@ const (
 	CloudRegionGoogleUSEast1     CloudRegion = "GOOGLE_US_EAST_1"
 	CloudRegionGoogleUSCentral1  CloudRegion = "GOOGLE_US_CENTRAL_1"
 	CloudRegionGoogleAsiaEast1   CloudRegion = "GOOGLE_ASIA_EAST_1"
+	CloudRegionExternal          CloudRegion = "EXTERNAL"
 )

--- a/models/encoding.go
+++ b/models/encoding.go
@@ -5,13 +5,14 @@ import (
 )
 
 type Encoding struct {
-	ID             *string                      `json:"id,omitempty"`
-	Name           *string                      `json:"name,omitempty"`
-	Description    *string                      `json:"description,omitempty"`
-	CustomData     map[string]interface{}       `json:"customData,omitempty"`
-	EncoderVersion bitmovintypes.EncoderVersion `json:"encoderVersion,omitempty"`
-	CloudRegion    bitmovintypes.CloudRegion    `json:"cloudRegion,omitempty"`
-	Status         string                       `json:"status,omitempty"`
+	ID               *string                      `json:"id,omitempty"`
+	Name             *string                      `json:"name,omitempty"`
+	Description      *string                      `json:"description,omitempty"`
+	CustomData       map[string]interface{}       `json:"customData,omitempty"`
+	EncoderVersion   bitmovintypes.EncoderVersion `json:"encoderVersion,omitempty"`
+	CloudRegion      bitmovintypes.CloudRegion    `json:"cloudRegion,omitempty"`
+	Status           string                       `json:"status,omitempty"`
+	InfrastructureID *string                      `json:"infrastructureId,omitempty"`
 }
 
 type EncodingData struct {


### PR DESCRIPTION
Added the ability to do on-premise encodings with the golang client.
Only needed the `infrastructureId` and the external CloudRegion