### PR TITLE
Fixed example for TS fairplay DRM

### DIFF
--- a/examples/live/create_drm_live_encoding.go
+++ b/examples/live/create_drm_live_encoding.go
@@ -451,7 +451,7 @@ func main() {
 		EncodingID:      encodingResp.Data.Result.ID,
 		StreamID:        aacStreamResp.Data.Result.ID,
 		MuxingID:        audioTsMuxingResp.Data.Result.ID,
-		DRMID:		     tsDrmAudio.Data.Result.ID,
+		DRMID:           tsDrmAudio.Data.Result.ID,
 	}
 	audioMediaInfoResp, err := hlsService.AddMediaInfo(*hlsManifestResp.Data.Result.ID, audioMediaInfo)
 	errorHandler(audioMediaInfoResp.Status, err)
@@ -463,7 +463,7 @@ func main() {
 		EncodingID:  encodingResp.Data.Result.ID,
 		StreamID:    videoStream1080pResp.Data.Result.ID,
 		MuxingID:    videoTsMuxing1080Resp.Data.Result.ID,
-		DRMID:		 tsDrm1080p.Data.Result.ID,
+		DRMID:       tsDrm1080p.Data.Result.ID,
 	}
 	video1080pStreamInfoResponse, err := hlsService.AddStreamInfo(*hlsManifestResp.Data.Result.ID, video1080pStreamInfo)
 	errorHandler(video1080pStreamInfoResponse.Status, err)
@@ -475,7 +475,7 @@ func main() {
 		EncodingID:  encodingResp.Data.Result.ID,
 		StreamID:    videoStream720pResp.Data.Result.ID,
 		MuxingID:    videoTsMuxing720Resp.Data.Result.ID,
-		DRMID:		 tsDrm720p.Data.Result.ID,
+		DRMID:       tsDrm720p.Data.Result.ID,
 	}
 	video720pStreamInfoResponse, err := hlsService.AddStreamInfo(*hlsManifestResp.Data.Result.ID, video720pStreamInfo)
 	errorHandler(video720pStreamInfoResponse.Status, err)

--- a/services/drm_service.go
+++ b/services/drm_service.go
@@ -128,7 +128,7 @@ func (s *DrmService) CreateTsDrm(encodingId string, tsMuxingId string, drm inter
 			return nil, err
 		}
 
-		enpointUrl := requestUrl + "/fairlplay"
+		enpointUrl := requestUrl + "/fairplay"
 		response, err := s.RestService.Create(enpointUrl, b)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixed typo in fairplay URL for TS
Fixed example for TS fairplay DRM
Changed to write dash and hls segments into different sub folders