### PR TITLE
services/encoding: add method to retrieve mp4 muxing information

### DIFF
--- a/models/encoding.go
+++ b/models/encoding.go
@@ -250,6 +250,51 @@ type MP4MuxingListResponse struct {
 	Data      MP4MuxingListData            `json:"data,omitempty"`
 }
 
+type VideoTrack struct {
+	Index       *int64   `json:"index,omitempty"`
+	Codec       *string  `json:"codec,omitempty"`
+	CodecIso    *string  `json:"codecIso,omitempty"`
+	FrameWidth  *int64   `json:"frameWidth,omitempty"`
+	FrameHeight *int64   `json:"frameHeight,omitempty"`
+	Duration    *float64 `json:"duration,omitempty"`
+}
+
+type AudioTrack struct {
+	Index    *int64   `json:"index,omitempty"`
+	Codec    *string  `json:"codec,omitempty"`
+	CodecIso *string  `json:"codecIso,omitempty"`
+	Duration *float64 `json:"duration,omitempty"`
+}
+
+type MP4MuxingInformationResult struct {
+	MimeType         *string      `json:"mimeType,omitempty"`
+	FileSize         *int64       `json:"fileSize,omitempty"`
+	ContainerFormat  *string      `json:"containerFormat,omitempty"`
+	ContainerBitrate *int64       `json:"containerBitrate,omitempty"`
+	Duration         *float64     `json:"duration,omitempty"`
+	VideoTracks      []VideoTrack `json:"videoTracks,omitempty"`
+	AudioTracks      []AudioTrack `json:"audioTracks,omitempty"`
+}
+
+type MP4MuxingInformationData struct {
+	//Success fields
+	Result   MP4MuxingInformationResult `json:"result,omitempty"`
+	Messages []Message                  `json:"messages,omitempty"`
+
+	//Error fields
+	Code             *int64   `json:"code,omitempty"`
+	Message          *string  `json:"message,omitempty"`
+	DeveloperMessage *string  `json:"developerMessage,omitempty"`
+	Links            []Link   `json:"links,omitempty"`
+	Details          []Detail `json:"details,omitempty"`
+}
+
+type MP4MuxingInformationResponse struct {
+	RequestID *string                      `json:"requestId,omitempty"`
+	Status    bitmovintypes.ResponseStatus `json:"status,omitempty"`
+	Data      MP4MuxingInformationData     `json:"data,omitempty"`
+}
+
 type ProgressiveMOVMuxing struct {
 	ID          *string                `json:"id,omitempty"`
 	Name        *string                `json:"name,omitempty"`

--- a/services/encoding_service.go
+++ b/services/encoding_service.go
@@ -404,6 +404,20 @@ func (s *EncodingService) RetrieveMP4MuxingCustomData(encodingID string, mp4ID s
 	return &r, nil
 }
 
+func (s *EncodingService) RetrieveMP4MuxingInformation(encodingID string, mp4MuxingID string) (*models.MP4MuxingInformationResponse, error) {
+	path := EncodingEndpoint + "/" + encodingID + "/" + "muxings/mp4" + "/" + mp4MuxingID + "/information"
+	o, err := s.RestService.Retrieve(path)
+	if err != nil {
+		return nil, err
+	}
+	var r models.MP4MuxingInformationResponse
+	err = json.Unmarshal(o, &r)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
 func (s *EncodingService) AddProgressiveMOVMuxing(encodingID string, a *models.ProgressiveMOVMuxing) (*models.ProgressiveMOVMuxingResponse, error) {
 	b, err := json.Marshal(*a)
 	if err != nil {


### PR DESCRIPTION
This PR adds:
-  some encoding models for mp4 muxing information
- a method to retrieve mp4 muxing information
