### PR TITLE
Fix Small Issues in Examples

### DIFF
--- a/bitmovintypes/stream_conditions.go
+++ b/bitmovintypes/stream_conditions.go
@@ -18,3 +18,10 @@ const (
 	ConditionTypeOr        ConditionType = "OR"
 	ConditionTypeCondition ConditionType = "CONDITION"
 )
+
+type ConditionMode string
+
+const (
+	ConditionModeDropMuxing ConditionMode = "DROP_MUXING"
+	ConditionModeDropStream ConditionMode = "DROP_STREAM"
+)

--- a/examples/create_config.go
+++ b/examples/create_config.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	bitmovin := bitmovin.NewBitmovin("YOUR API KEY")
+	bitmovin := bitmovin.NewBitmovinDefault("YOUR API KEY")
 
 	config := models.NewH264CodecConfigBuilder(`H264 Default Config`).
 		Width(1920).Height(1080).Bitrate(4500000).
@@ -24,5 +24,5 @@ func main() {
 
 	svc := services.NewH264CodecConfigurationService(bitmovin)
 	response, _ := svc.Create(config)
-	log.Printf("Created h264 Code Configuration with ID: %s", response.Data.Result.ID)
+	log.Printf("Created h264 Code Configuration with ID: %s With Name: %s", *response.Data.Result.ID, *response.Data.Result.Name)
 }

--- a/examples/create_simple_encoding_gcp_dash.go
+++ b/examples/create_simple_encoding_gcp_dash.go
@@ -282,7 +282,7 @@ func errorHandler(responseStatus bitmovintypes.ResponseStatus, err error) {
 		fmt.Println(err)
 	} else if responseStatus == "ERROR" {
 		fmt.Println("api error")
-		fmt.Println("Received Error: %v", err)
+		fmt.Printf("Received Error: %s\n", err)
 		panic(err)
 	}
 }

--- a/models/encoding.go
+++ b/models/encoding.go
@@ -108,16 +108,17 @@ type StreamItem struct {
 }
 
 type FMP4Muxing struct {
-	ID              *string                `json:"id,omitempty"`
-	Name            *string                `json:"name,omitempty"`
-	Description     *string                `json:"description,omitempty"`
-	CustomData      map[string]interface{} `json:"customData,omitempty"`
-	Streams         []StreamItem           `json:"streams,omitempty"`
-	Outputs         []Output               `json:"outputs,omitempty"`
-	SegmentLength   *float64               `json:"segmentLength,omitempty"`
-	SegmentNaming   *string                `json:"segmentNaming,omitempty"`
-	InitSegmentName *string                `json:"initSegmentName,omitempty"`
-	AvgBitrate      *int                   `json:"avgBitrate,omitempty"`
+	ID                   *string                     `json:"id,omitempty"`
+	Name                 *string                     `json:"name,omitempty"`
+	Description          *string                     `json:"description,omitempty"`
+	CustomData           map[string]interface{}      `json:"customData,omitempty"`
+	Streams              []StreamItem                `json:"streams,omitempty"`
+	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
+	Outputs              []Output                    `json:"outputs,omitempty"`
+	SegmentLength        *float64                    `json:"segmentLength,omitempty"`
+	SegmentNaming        *string                     `json:"segmentNaming,omitempty"`
+	InitSegmentName      *string                     `json:"initSegmentName,omitempty"`
+	AvgBitrate           *int                        `json:"avgBitrate,omitempty"`
 }
 
 type FMP4MuxingData struct {
@@ -157,14 +158,15 @@ type FMP4MuxingListResponse struct {
 }
 
 type TSMuxing struct {
-	ID            *string                `json:"id,omitempty"`
-	Name          *string                `json:"name,omitempty"`
-	Description   *string                `json:"description,omitempty"`
-	CustomData    map[string]interface{} `json:"customData,omitempty"`
-	Streams       []StreamItem           `json:"streams,omitempty"`
-	Outputs       []Output               `json:"outputs,omitempty"`
-	SegmentLength *float64               `json:"segmentLength,omitempty"`
-	SegmentNaming *string                `json:"segmentNaming,omitempty"`
+	ID                   *string                     `json:"id,omitempty"`
+	Name                 *string                     `json:"name,omitempty"`
+	Description          *string                     `json:"description,omitempty"`
+	CustomData           map[string]interface{}      `json:"customData,omitempty"`
+	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
+	Streams              []StreamItem                `json:"streams,omitempty"`
+	Outputs              []Output                    `json:"outputs,omitempty"`
+	SegmentLength        *float64                    `json:"segmentLength,omitempty"`
+	SegmentNaming        *string                     `json:"segmentNaming,omitempty"`
 }
 
 type TSMuxingData struct {
@@ -204,14 +206,15 @@ type TSMuxingListResponse struct {
 }
 
 type MP4Muxing struct {
-	ID               *string                `json:"id,omitempty"`
-	Name             *string                `json:"name,omitempty"`
-	Description      *string                `json:"description,omitempty"`
-	CustomData       map[string]interface{} `json:"customData,omitempty"`
-	Streams          []StreamItem           `json:"streams,omitempty"`
-	Outputs          []Output               `json:"outputs,omitempty"`
-	Filename         *string                `json:"filename,omitempty"`
-	FragmentDuration *int64                 `json:"fragmentDuration,omitempty"`
+	ID                   *string                     `json:"id,omitempty"`
+	Name                 *string                     `json:"name,omitempty"`
+	Description          *string                     `json:"description,omitempty"`
+	CustomData           map[string]interface{}      `json:"customData,omitempty"`
+	Streams              []StreamItem                `json:"streams,omitempty"`
+	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
+	Outputs              []Output                    `json:"outputs,omitempty"`
+	Filename             *string                     `json:"filename,omitempty"`
+	FragmentDuration     *int64                      `json:"fragmentDuration,omitempty"`
 }
 
 type MP4MuxingData struct {
@@ -296,13 +299,14 @@ type MP4MuxingInformationResponse struct {
 }
 
 type ProgressiveMOVMuxing struct {
-	ID          *string                `json:"id,omitempty"`
-	Name        *string                `json:"name,omitempty"`
-	Description *string                `json:"description,omitempty"`
-	CustomData  map[string]interface{} `json:"customData,omitempty"`
-	Streams     []StreamItem           `json:"streams,omitempty"`
-	Outputs     []Output               `json:"outputs,omitempty"`
-	Filename    *string                `json:"filename,omitempty"`
+	ID                   *string                     `json:"id,omitempty"`
+	Name                 *string                     `json:"name,omitempty"`
+	Description          *string                     `json:"description,omitempty"`
+	CustomData           map[string]interface{}      `json:"customData,omitempty"`
+	Streams              []StreamItem                `json:"streams,omitempty"`
+	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
+	Outputs              []Output                    `json:"outputs,omitempty"`
+	Filename             *string                     `json:"filename,omitempty"`
 }
 
 type ProgressiveMOVMuxingData struct {
@@ -371,13 +375,14 @@ type ProgressiveMOVMuxingListResponse struct {
 }
 
 type ProgressiveWebMMuxing struct {
-	ID          *string                `json:"id,omitempty"`
-	Name        *string                `json:"name,omitempty"`
-	Description *string                `json:"description,omitempty"`
-	CustomData  map[string]interface{} `json:"customData,omitempty"`
-	Streams     []StreamItem           `json:"streams,omitempty"`
-	Outputs     []Output               `json:"outputs,omitempty"`
-	Filename    *string                `json:"filename,omitempty"`
+	ID                   *string                     `json:"id,omitempty"`
+	Name                 *string                     `json:"name,omitempty"`
+	Description          *string                     `json:"description,omitempty"`
+	CustomData           map[string]interface{}      `json:"customData,omitempty"`
+	Streams              []StreamItem                `json:"streams,omitempty"`
+	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
+	Outputs              []Output                    `json:"outputs,omitempty"`
+	Filename             *string                     `json:"filename,omitempty"`
 }
 
 type ProgressiveWebMMuxingData struct {


### PR DESCRIPTION
Make the first example compile and work again. Fix a (correct) vet warning.