### PR TITLE
Enable DASH On-Demand & HLS Byte Range with Fragmented MP4 Muxings

### DIFF
--- a/bitmovintypes/dash_manifest_profile.go
+++ b/bitmovintypes/dash_manifest_profile.go
@@ -5,5 +5,4 @@ type DASHManifestProfile string
 const (
 	DASHManifestProfileLive     DASHManifestProfile = "LIVE"
 	DASHManifestProfileOnDemand DASHManifestProfile = "ON_DEMAND"
-
 )

--- a/bitmovintypes/dash_manifest_profile.go
+++ b/bitmovintypes/dash_manifest_profile.go
@@ -1,0 +1,9 @@
+package bitmovintypes
+
+type DASHManifestProfile string
+
+const (
+	DASHManifestProfileLive     DASHManifestProfile = "LIVE"
+	DASHManifestProfileOnDemand DASHManifestProfile = "ON_DEMAND"
+
+)

--- a/bitmovintypes/fragmented_mp4_muxing_manifest_type.go
+++ b/bitmovintypes/fragmented_mp4_muxing_manifest_type.go
@@ -1,0 +1,8 @@
+package bitmovintypes
+
+type FragmentedMP4MuxingManifestType string
+
+const (
+	FragmentedMP4MuxingManifestTypeSmooth        FragmentedMP4MuxingManifestType = "SMOOTH"
+	FragmentedMP4MuxingManifestTypeDASHOnDemand  FragmentedMP4MuxingManifestType = "DASH_ON_DEMAND"
+)

--- a/bitmovintypes/fragmented_mp4_muxing_manifest_type.go
+++ b/bitmovintypes/fragmented_mp4_muxing_manifest_type.go
@@ -5,4 +5,5 @@ type FragmentedMP4MuxingManifestType string
 const (
 	FragmentedMP4MuxingManifestTypeSmooth        FragmentedMP4MuxingManifestType = "SMOOTH"
 	FragmentedMP4MuxingManifestTypeDASHOnDemand  FragmentedMP4MuxingManifestType = "DASH_ON_DEMAND"
+	FragmentedMP4MuxingManifestTypeHlsByteRanges FragmentedMP4MuxingManifestType = "HLS_BYTE_RANGES"
 )

--- a/models/dash.go
+++ b/models/dash.go
@@ -3,11 +3,11 @@ package models
 import "github.com/bitmovin/bitmovin-go/bitmovintypes"
 
 type DashManifest struct {
-	ID           *string                           `json:"id"`
-	Name         *string                           `json:"name"`
-	Description  *string                           `json:"description"`
-	Outputs      []Output                          `json:"outputs"`
-	ManifestName *string                           `json:"manifestName"`
+	ID           *string                           `json:"id,omitempty"`
+	Name         *string                           `json:"name,omitempty"`
+	Description  *string                           `json:"description,omitempty"`
+	Outputs      []Output                          `json:"outputs,omitempty"`
+	ManifestName *string                           `json:"manifestName,omitempty"`
 	Profile      bitmovintypes.DASHManifestProfile `json:"profile,omitempty"`
 }
 

--- a/models/dash.go
+++ b/models/dash.go
@@ -3,11 +3,12 @@ package models
 import "github.com/bitmovin/bitmovin-go/bitmovintypes"
 
 type DashManifest struct {
-	ID           *string  `json:"id"`
-	Name         *string  `json:"name"`
-	Description  *string  `json:"description"`
-	Outputs      []Output `json:"outputs"`
-	ManifestName *string  `json:"manifestName"`
+	ID           *string                           `json:"id"`
+	Name         *string                           `json:"name"`
+	Description  *string                           `json:"description"`
+	Outputs      []Output                          `json:"outputs"`
+	ManifestName *string                           `json:"manifestName"`
+	Profile      bitmovintypes.DASHManifestProfile `json:"profile,omitempty"`
 }
 
 func (h *DashManifest) AddOutput(output *Output) {
@@ -199,4 +200,30 @@ type AdaptationSetContentProtectionResponse struct {
 	RequestID *string                            `json:"requestId,omitempty"`
 	Status    bitmovintypes.ResponseStatus       `json:"status,omitempty"`
 	Data      AdaptationSetContentProtectionData `json:"data,omitempty"`
+}
+
+type MP4Representation struct {
+	ID         *string `json:"id,omitempty"`
+	MuxingID   *string `json:"muxingId,omitempty"`
+	EncodingID *string `json:"encodingId,omitempty"`
+	FilePath   *string `json:"filePath,omitempty"`
+}
+
+type MP4RepresentationData struct {
+	//Success fields
+	Result   MP4Representation `json:"result,omitempty"`
+	Messages []Message         `json:"messages,omitempty"`
+
+	//Error fields
+	Code             *int64   `json:"code,omitempty"`
+	Message          *string  `json:"message,omitempty"`
+	DeveloperMessage *string  `json:"developerMessage,omitempty"`
+	Links            []Link   `json:"links,omitempty"`
+	Details          []Detail `json:"details,omitempty"`
+}
+
+type MP4RepresentationResponse struct {
+	RequestID *string                      `json:"requestId,omitempty"`
+	Status    bitmovintypes.ResponseStatus `json:"status,omitempty"`
+	Data      MP4RepresentationData        `json:"data,omitempty"`
 }

--- a/models/encoding.go
+++ b/models/encoding.go
@@ -212,15 +212,16 @@ type TSMuxingListResponse struct {
 }
 
 type MP4Muxing struct {
-	ID                   *string                     `json:"id,omitempty"`
-	Name                 *string                     `json:"name,omitempty"`
-	Description          *string                     `json:"description,omitempty"`
-	CustomData           map[string]interface{}      `json:"customData,omitempty"`
-	Streams              []StreamItem                `json:"streams,omitempty"`
-	StreamConditionsMode bitmovintypes.ConditionMode `json:"streamConditionsMode,omitempty"`
-	Outputs              []Output                    `json:"outputs,omitempty"`
-	Filename             *string                     `json:"filename,omitempty"`
-	FragmentDuration     *int64                      `json:"fragmentDuration,omitempty"`
+	ID                              *string                                       `json:"id,omitempty"`
+	Name                            *string                                       `json:"name,omitempty"`
+	Description                     *string                                       `json:"description,omitempty"`
+	CustomData                      map[string]interface{}                        `json:"customData,omitempty"`
+	Streams                         []StreamItem                                  `json:"streams,omitempty"`
+	StreamConditionsMode            bitmovintypes.ConditionMode                   `json:"streamConditionsMode,omitempty"`
+	Outputs                         []Output                                      `json:"outputs,omitempty"`
+	Filename                        *string                                       `json:"filename,omitempty"`
+	FragmentDuration                *int64                                        `json:"fragmentDuration,omitempty"`
+	FragmentedMP4MuxingManifestType bitmovintypes.FragmentedMP4MuxingManifestType `json:"fragmentedMP4MuxingManifestType,omitempty"`
 }
 
 type MP4MuxingData struct {

--- a/services/dash_manifest_service.go
+++ b/services/dash_manifest_service.go
@@ -344,3 +344,22 @@ func (s *DashManifestService) AddContentProtectionToAdaptationSet(manifestID str
 	}
 	return &r, nil
 }
+
+func (s *DashManifestService) AddMP4Representation(manifestID string, periodID string, adaptationSetID string, a *models.MP4Representation) (*models.MP4RepresentationResponse, error) {
+	b, err := json.Marshal(*a)
+	if err != nil {
+		return nil, err
+	}
+	path := DashManifestEndpoint + "/" + manifestID + "/" + "periods" + "/" + periodID + "/adaptationsets/" + adaptationSetID + "/representations/mp4"
+	o, err := s.RestService.Create(path, b)
+	if err != nil {
+		return nil, err
+	}
+	var r models.MP4RepresentationResponse
+	err = json.Unmarshal(o, &r)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+


### PR DESCRIPTION
Adds: https://bitmovin.com/docs/encoding/api-reference#/reference/encoding/manifests/add-mp4-representation