### PR TITLE
Adds missing rotation stream condition attribute

### DIFF
--- a/bitmovintypes/stream_conditions.go
+++ b/bitmovintypes/stream_conditions.go
@@ -9,6 +9,7 @@ const (
 	ConditionAttributeBitrate     ConditionAttribute = "BITRATE"
 	ConditionAttributeAspectRatio ConditionAttribute = "ASPECTRATIO"
 	ConditionAttributeInputStream ConditionAttribute = "INPUTSTREAM"
+	ConditionAttributeRotation    ConditionAttribute = "ROTATION"
 )
 
 type ConditionType string


### PR DESCRIPTION
This adds a missing stream condition attribute that is mentioned in the documentation.

https://bitmovin.com/docs/encoding/articles/stream-conditions#video-stream